### PR TITLE
FIX: mobile CSS

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -13,8 +13,6 @@ a:hover, a:focus{
 
 header {
     width: 315px;
-    float: left;
-    position: fixed;
     -webkit-font-smoothing:subpixel-antialiased
 }
 

--- a/assets/css/style_full.scss
+++ b/assets/css/style_full.scss
@@ -20,8 +20,6 @@ a:hover, a:focus{
 
 header {
     width: 315px;
-    float: left;
-    position: fixed;
     -webkit-font-smoothing:subpixel-antialiased
 }
 


### PR DESCRIPTION
Fix the mobile version of the website, removing a few CSS properties on the website's theme.

It had no effect on the desktop website.

Before:
![Before](https://i.imgur.com/iBNZ1jG.png)

After:
![After](https://i.imgur.com/yBjNtj2.png)